### PR TITLE
Set react@^16.8.0 as a peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -77,7 +77,6 @@
   },
   "dependencies": {
     "@types/react": "^16.8.8",
-    "react": "^16.8.5",
     "use-immer": "^0.1.0"
   },
   "devDependencies": {
@@ -97,6 +96,7 @@
     "lodash.camelcase": "^4.3.0",
     "prettier": "^1.14.3",
     "prompt": "^1.0.0",
+    "react": "^16.8.5",
     "react-dom": "^16.8.5",
     "react-testing-library": "^6.0.2",
     "replace-in-file": "^3.4.2",
@@ -116,5 +116,8 @@
     "hooks": {
       "pre-commit": "lint-staged"
     }
+  },
+  "peerDependencies": {
+    "react": "^16.8.0"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -6626,7 +6626,7 @@ react-testing-library@^6.0.2:
 
 react@^16.8.5:
   version "16.8.5"
-  resolved "https://registry.npmjs.org/react/-/react-16.8.5.tgz#49be3b655489d74504ad994016407e8a0445de66"
+  resolved "https://registry.yarnpkg.com/react/-/react-16.8.5.tgz#49be3b655489d74504ad994016407e8a0445de66"
   integrity sha512-daCb9TD6FZGvJ3sg8da1tRAtIuw29PbKZW++NN4wqkbEvxL+bZpaaYb4xuftW/SpXmgacf1skXl/ddX6CdOlDw==
   dependencies:
     loose-envify "^1.1.0"
@@ -7130,9 +7130,9 @@ scheduler@^0.13.5:
     loose-envify "^1.1.0"
     object-assign "^4.1.1"
 
-semantic-release@^15.9.16:
+semantic-release@^15.13.3:
   version "15.13.3"
-  resolved "https://registry.npmjs.org/semantic-release/-/semantic-release-15.13.3.tgz#412720b9c09f39f04df67478fa409a914107e05b"
+  resolved "https://registry.yarnpkg.com/semantic-release/-/semantic-release-15.13.3.tgz#412720b9c09f39f04df67478fa409a914107e05b"
   integrity sha512-cax0xPPTtsxHlrty2HxhPql2TTvS74Ni2O8BzwFHxNY/mviVKEhI4OxHzBYJkpVxx1fMVj36+oH7IlP+SJtPNA==
   dependencies:
     "@semantic-release/commit-analyzer" "^6.1.0"


### PR DESCRIPTION
Thank you for this amazing library! I can't wait to use it in my next project!

This PR changes the `react@^16.8.5` dependency to a `react@^16.8.0` peer dependency so the user of this library can choose the React version with hooks that suit them the best. If you e.g. [paste the README code example directly into CodeSandbox you will get an error because two versions of React is installed at the same time](https://codesandbox.io/s/0ozvlx97n).